### PR TITLE
Remove `-R -Kenv=dev` in the update command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,7 +52,7 @@ runs:
       shell: bash
 
     - name: Update dependencies of ${{ github.repository }}
-      run: lake -R -Kenv=dev update
+      run: lake update
       shell: bash
 
     - name: Check if lean-toolchain or lake-manifest.json were updated


### PR DESCRIPTION
This PR removes the `-R -Kenv=dev` in the `lake -R -Kenv=dev update` command in order to comply to the standard practice. 

Please consider tagging a release before merging this PR.