### PR TITLE
uncapitalize the `SECRET` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ jobs:
 
 ### If you want to receive notifications on Zulip when the update fails
 
-After registering your Zulip API Key in your repository SECRETS, configure as follows:
+After registering your Zulip API Key in your repository secrets, configure as follows:
 
 ```yml
 name: Update Lean Project


### PR DESCRIPTION
<!-- Please ensure that the README descriptions are up-to-date and consistent with action.yml.

If you are using copilot-edit, you can simply instruct it to do this task by typing "sync".
-->