### PR TITLE
update versions of GitHub Action

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+# See the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Update Lean package
         id: update
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Update Lean package
         id: update
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Update Lean package
         id: update
@@ -80,10 +80,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Update Lean project
         uses: leanprover-community/lean-update@main
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Update Lean project
         uses: leanprover-community/lean-update@main
         with:
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Update Lean project
         id: lean-update

--- a/action.yml
+++ b/action.yml
@@ -221,7 +221,7 @@ runs:
           inputs.on_update_succeeds == 'pr' &&
           steps.check-update.outputs.do_update == 'true' &&
           steps.check-update.outputs.lean_toolchain_updated == 'true'
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@v8
       with:
         title: "Updates available and ready to merge"
         body: |
@@ -238,7 +238,7 @@ runs:
           inputs.on_update_succeeds == 'pr' &&
           steps.check-update.outputs.do_update == 'true' &&
           steps.check-update.outputs.lean_toolchain_updated == 'false'
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@v8
       with:
         title: "Updates available and ready to merge"
         body: ""
@@ -266,7 +266,7 @@ runs:
 
     - name: Commit update if the updated lean build was successful
       if: steps.build-lean.outcome == 'success' && inputs.on_update_succeeds == 'commit' && steps.check-update.outputs.do_update == 'true'
-      uses: EndBug/add-and-commit@v9.1.4
+      uses: EndBug/add-and-commit@v10
       with:
         default_author: github_actions
       env:


### PR DESCRIPTION
## Summary

Updates GitHub Action references to their current major versions.

- `peter-evans/create-pull-request`: `v7` -> `v8`
- `EndBug/add-and-commit`: `v9.1.4` -> `v10`
- README examples: `actions/checkout@v5` -> `actions/checkout@v6`
- Test workflow: `actions/checkout@v5` -> `actions/checkout@v6`
- Test workflow: `actions/setup-node@v4` -> `actions/setup-node@v6`