### PR TITLE
Always expose `latest_lean` and skip dependency package toolchain updates

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,3 +73,25 @@ jobs:
             exit 1
           fi
           echo "notify output test passed"
+
+  latest_lean_output_test_with_dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Update Lean package
+        id: update
+        uses: ./
+        with:
+          on_update_succeeds: "silent"
+          lake_package_directory: "./Fixtures/HasDep"
+
+      - name: output assertion of latest_lean
+        run: |
+          echo "Latest Lean version: ${{ steps.update.outputs.latest_lean }}"
+          if [[ ! "${{ steps.update.outputs.latest_lean }}" =~ ^v ]]; then
+            echo "Error: The latest_lean output should start with 'v' even when dependencies are present"
+            exit 1
+          fi
+          echo "latest_lean output test with dependencies passed"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,3 +95,42 @@ jobs:
             exit 1
           fi
           echo "latest_lean output test with dependencies passed"
+
+  latest_lean_output_test_with_update_lean_toolchain_never:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Record original lean-toolchain
+        id: original-toolchain
+        run: echo "content=$(cat Fixtures/SmokeSuccess/lean-toolchain)" >> "$GITHUB_OUTPUT"
+
+      - name: Update Lean package
+        id: update
+        uses: ./
+        with:
+          on_update_succeeds: "silent"
+          lake_package_directory: "./Fixtures/SmokeSuccess"
+          update_lean_toolchain: "never"
+
+      - name: output assertion of latest_lean
+        run: |
+          echo "Latest Lean version: ${{ steps.update.outputs.latest_lean }}"
+          if [[ ! "${{ steps.update.outputs.latest_lean }}" =~ ^v ]]; then
+            echo "Error: The latest_lean output should start with 'v' even when update_lean_toolchain is never"
+            exit 1
+          fi
+          echo "latest_lean output test with update_lean_toolchain=never passed"
+
+      - name: lean-toolchain should not be updated
+        run: |
+          CURRENT_TOOLCHAIN=$(cat Fixtures/SmokeSuccess/lean-toolchain)
+          ORIGINAL_TOOLCHAIN="${{ steps.original-toolchain.outputs.content }}"
+          echo "Original lean-toolchain: $ORIGINAL_TOOLCHAIN"
+          echo "Current lean-toolchain: $CURRENT_TOOLCHAIN"
+          if [[ "$CURRENT_TOOLCHAIN" != "$ORIGINAL_TOOLCHAIN" ]]; then
+            echo "Error: lean-toolchain should not be updated when update_lean_toolchain is never"
+            exit 1
+          fi
+          echo "lean-toolchain unchanged test passed"

--- a/LeanUpdate.lean
+++ b/LeanUpdate.lean
@@ -3,6 +3,6 @@ module
 import LeanUpdate.CheckChanges
 import LeanUpdate.IO
 import LeanUpdate.FindDep
-import LeanUpdate.GH
+import LeanUpdate.GitHub
 import LeanUpdate.Input
 import LeanUpdate.UpdateLeanToolchain

--- a/LeanUpdate/CheckChanges.lean
+++ b/LeanUpdate/CheckChanges.lean
@@ -1,6 +1,6 @@
 module
 
-import LeanUpdate.GH
+import LeanUpdate.GitHub.Action.Env
 import LeanUpdate.Input
 
 open IO Process System
@@ -57,7 +57,7 @@ def checkChanges (targetLakePackageDir : FilePath) : IO CheckChangesResult := do
 
 /-- Run the update checker command. -/
 public def runCheckChanges : IO Unit := do
-  let updateIfModified ← Input.get UpdateIfModified
+  let updateIfModified ← GitHub.Action.Input.get UpdateIfModified
   let targetLakePackageDir ← getTargetLakePackageDirectory
   let result ← checkChanges targetLakePackageDir
 
@@ -77,13 +77,13 @@ public def runCheckChanges : IO Unit := do
   let newLeanToolchainContent := result.leanToolchain.newContent
   IO.println s!"info: files_changed={filesChanged}, do_update={doUpdate}, changed_files={changedFiles}, lean_toolchain_updated={leanToolchainUpdated}"
 
-  GH.writeGHEnv "FILES_CHANGED" (toString filesChanged)
-  GH.writeGHEnv "CHANGED_FILES" (String.intercalate " " changedFiles)
-  GH.writeGHEnv "DO_UPDATE" (toString doUpdate)
-  GH.writeGHEnv "LEAN_TOOLCHAIN_UPDATED" (toString leanToolchainUpdated)
+  GitHub.Action.writeGHEnv "FILES_CHANGED" (toString filesChanged)
+  GitHub.Action.writeGHEnv "CHANGED_FILES" (String.intercalate " " changedFiles)
+  GitHub.Action.writeGHEnv "DO_UPDATE" (toString doUpdate)
+  GitHub.Action.writeGHEnv "LEAN_TOOLCHAIN_UPDATED" (toString leanToolchainUpdated)
 
   if leanToolchainUpdated then
     IO.println s!"info: new lean-toolchain content: {newLeanToolchainContent}"
   else
     IO.println s!"info: lean-toolchain not updated, no new content"
-  GH.writeGHEnv "NEW_LEAN_TOOLCHAIN_CONTENT" newLeanToolchainContent
+  GitHub.Action.writeGHEnv "NEW_LEAN_TOOLCHAIN_CONTENT" newLeanToolchainContent

--- a/LeanUpdate/CreateIssue.lean
+++ b/LeanUpdate/CreateIssue.lean
@@ -2,7 +2,7 @@ module
 
 import Lean
 import LeanUpdate.IO
-import LeanUpdate.GH
+import LeanUpdate.GitHub.Action.Env
 import LeanUpdate.Input
 
 open IO Process System
@@ -48,7 +48,7 @@ def getGitHubRepository : IO String := do
   match github_repository? <|> gh_repo? with
   | .some repo => pure repo
   | .none =>
-    if (← GH.isRunningGHAction) then
+    if (← GitHub.Action.isRunningGHAction) then
       throw <| IO.userError "Environment variable 'GITHUB_REPOSITORY' not found"
     else
       pure "owner/repo"
@@ -60,7 +60,7 @@ def getIssueConfig (kind : IssueKind) : IO IssueConfig := do
     labelName := kind.labelName
     labelColor := kind.labelColor
     repo := ← getGitHubRepository
-    changedFiles := ← GH.readGHEnv! "CHANGED_FILES"
+    changedFiles := ← GitHub.Action.readGHEnv! "CHANGED_FILES"
   }
 
 def splitChangedFiles (changedFiles : String) : List String :=
@@ -228,8 +228,8 @@ def printIssuePreview (config : IssueConfig) (body : String) : IO Unit := do
 public def runCreateIssue (kind : IssueKind) : IO Unit := do
   let config ← getIssueConfig kind
   let targetLakePackageDir ← getTargetLakePackageDirectory
-  let buildArgs ← Input.get BuildArgs
-  let isRunningGHAction ← GH.isRunningGHAction
+  let buildArgs ← GitHub.Action.Input.get BuildArgs
+  let isRunningGHAction ← GitHub.Action.isRunningGHAction
   let buildOutput ← runLakeBuild targetLakePackageDir buildArgs
   let body := createIssueBody config buildOutput
   if !isRunningGHAction then

--- a/LeanUpdate/FindDep.lean
+++ b/LeanUpdate/FindDep.lean
@@ -1,6 +1,6 @@
 module
 
-import LeanUpdate.GH
+import LeanUpdate.GitHub.Action.Env
 public import Lake.Load.Manifest
 import LeanUpdate.Input
 
@@ -16,9 +16,9 @@ public def runFindDependencies : IO Unit := do
   let hasDep : Bool := !packageNames.isEmpty
   if hasDep then
     IO.println s!"The repository has some dependencies: {packageNames}"
-    GH.writeOutput "has_dependency" "true"
-    GH.writeGHEnv "HAS_DEPENDENCY" "true"
+    GitHub.Action.writeGHOutput "has_dependency" "true"
+    GitHub.Action.writeGHEnv "HAS_DEPENDENCY" "true"
   else
     IO.println "The repository has no dependencies."
-    GH.writeOutput "has_dependency" "false"
-    GH.writeGHEnv "HAS_DEPENDENCY" "false"
+    GitHub.Action.writeGHOutput "has_dependency" "false"
+    GitHub.Action.writeGHEnv "HAS_DEPENDENCY" "false"

--- a/LeanUpdate/GitHub.lean
+++ b/LeanUpdate/GitHub.lean
@@ -1,0 +1,4 @@
+module
+
+import LeanUpdate.GitHub.Action.Env
+import LeanUpdate.GitHub.Action.Input

--- a/LeanUpdate/GitHub/Action/Env.lean
+++ b/LeanUpdate/GitHub/Action/Env.lean
@@ -28,7 +28,7 @@ public def writeGHOutput (key value : String) : IO Unit := do
     IO.FS.appendLineToFile GITHUB_OUTPUT line
   else
     IO.FS.appendLineToFile Local.GITHUB_OUTPUT line
-  IO.println s!"[Update GITHUB_OUTPUT]: {key}={value}"
+  IO.println s!"[{decl_name%}]: {key}={value}"
 
 /-- write a key-value pair to the GitHub Actions environment -/
 public def writeGHEnv (key value : String) : IO Unit := do
@@ -38,7 +38,7 @@ public def writeGHEnv (key value : String) : IO Unit := do
     IO.FS.appendLineToFile GITHUB_ENV line
   else
     IO.FS.appendLineToFile Local.GITHUB_ENV line
-  IO.println s!"[Update GITHUB_ENV]: {line}"
+  IO.println s!"[{decl_name%}]: {line}"
 
 def parseGHEnvLine (key line : String) : Option String :=
   let envLinePrefix := s!"LEAN_UPDATE_{key}="

--- a/LeanUpdate/GitHub/Action/Env.lean
+++ b/LeanUpdate/GitHub/Action/Env.lean
@@ -2,6 +2,10 @@ module
 
 import LeanUpdate.IO
 import LeanUpdate.HasParser
+import LeanUpdate.Terminal
+import Std
+
+open Std
 
 /-- this is used for local testing -/
 def Local.GITHUB_OUTPUT : String := "tmp/output.txt"
@@ -28,7 +32,7 @@ public def writeGHOutput (key value : String) : IO Unit := do
     IO.FS.appendLineToFile GITHUB_OUTPUT line
   else
     IO.FS.appendLineToFile Local.GITHUB_OUTPUT line
-  IO.println s!"[{decl_name%}]: {key}={value}"
+  IO.println <| log% s!"{key}={value}"
 
 /-- write a key-value pair to the GitHub Actions environment -/
 public def writeGHEnv (key value : String) : IO Unit := do
@@ -38,7 +42,7 @@ public def writeGHEnv (key value : String) : IO Unit := do
     IO.FS.appendLineToFile GITHUB_ENV line
   else
     IO.FS.appendLineToFile Local.GITHUB_ENV line
-  IO.println s!"[{decl_name%}]: {line}"
+  IO.println <| log% line
 
 def parseGHEnvLine (key line : String) : Option String :=
   let envLinePrefix := s!"LEAN_UPDATE_{key}="

--- a/LeanUpdate/GitHub/Action/Env.lean
+++ b/LeanUpdate/GitHub/Action/Env.lean
@@ -1,7 +1,7 @@
 module
 
 import LeanUpdate.IO
-import LeanUpdate.HasParser
+public import LeanUpdate.HasParser
 import LeanUpdate.Terminal
 import Std
 
@@ -79,6 +79,13 @@ public def readGHEnv (key : String) : IO (Option String) := do
   else
     readLocalGHEnv key
 
+/-- Read and parse a value previously written through `GitHub.Action.writeGHEnv`. -/
+public def readGHEnvAs (key : String) (expectedType : Type) [HasParser expectedType] : IO (Option expectedType) := do
+  let some valueStr ← readGHEnv key
+    | pure none
+  let value ← IO.ofExcept <| parseAs expectedType valueStr
+  pure <| some value
+
 /-- Read a value previously written through `GitHub.Action.writeGHEnv`.
 This function throws an error if the environment variable is not found or is empty. -/
 public def readGHEnv! (key : String) : IO String := do
@@ -88,5 +95,11 @@ public def readGHEnv! (key : String) : IO String := do
     pure value
   else
     readLocalGHEnv key
+
+/-- Read and parse a value previously written through `GitHub.Action.writeGHEnv`.
+This function throws an error if the environment variable is not found or is empty. -/
+public def readGHEnvAs! (key : String) (expectedType : Type) [HasParser expectedType] : IO expectedType := do
+  let valueStr ← readGHEnv! key
+  IO.ofExcept <| parseAs expectedType valueStr
 
 end GitHub.Action

--- a/LeanUpdate/GitHub/Action/Env.lean
+++ b/LeanUpdate/GitHub/Action/Env.lean
@@ -3,18 +3,16 @@ module
 import LeanUpdate.IO
 import LeanUpdate.HasParser
 
-/-
-utils for GitHub Action
--/
-
 /-- this is used for local testing -/
 def Local.GITHUB_OUTPUT : String := "tmp/output.txt"
 
 /-- this is used for local testing -/
 def Local.GITHUB_ENV : String := "tmp/env.txt"
 
+namespace GitHub.Action
+
 /-- detect if the code is running in a GitHub Action environment -/
-public def GH.isRunningGHAction : IO Bool := do
+public def isRunningGHAction : IO Bool := do
   let isActionStr? ← IO.getEnv "GITHUB_ACTIONS"
   match isActionStr? with
   | .some isActionStr =>
@@ -22,12 +20,8 @@ public def GH.isRunningGHAction : IO Bool := do
     pure isAction
   | .none => pure false
 
-def IO.FS.appendLineToFile (path : System.FilePath) (line : String) : IO Unit :=
-  IO.FS.withFile path IO.FS.Mode.append fun h => do
-    h.putStr s!"{line}\n"
-
 /-- write a key-value pair to the GitHub Actions output -/
-public def GH.writeOutput (key value : String) : IO Unit := do
+public def writeGHOutput (key value : String) : IO Unit := do
   let line := s!"{key}={value}"
   if (← isRunningGHAction) then
     let GITHUB_OUTPUT ← IO.getEnv! "GITHUB_OUTPUT"
@@ -37,7 +31,7 @@ public def GH.writeOutput (key value : String) : IO Unit := do
   IO.println s!"[Update GITHUB_OUTPUT]: {key}={value}"
 
 /-- write a key-value pair to the GitHub Actions environment -/
-public def GH.writeGHEnv (key value : String) : IO Unit := do
+public def writeGHEnv (key value : String) : IO Unit := do
   let line := s!"LEAN_UPDATE_{key}={value}"
   if (← isRunningGHAction) then
     let GITHUB_ENV ← IO.getEnv! "GITHUB_ENV"
@@ -46,7 +40,7 @@ public def GH.writeGHEnv (key value : String) : IO Unit := do
     IO.FS.appendLineToFile Local.GITHUB_ENV line
   IO.println s!"[Update GITHUB_ENV]: {line}"
 
-def GH.parseGHEnvLine (key line : String) : Option String :=
+def parseGHEnvLine (key line : String) : Option String :=
   let envLinePrefix := s!"LEAN_UPDATE_{key}="
   if line.startsWith envLinePrefix then
     some <| (line.drop envLinePrefix.length).toString
@@ -54,39 +48,41 @@ def GH.parseGHEnvLine (key line : String) : Option String :=
     none
 
 #guard
-  let actual := GH.parseGHEnvLine "CHANGED_FILES" "LEAN_UPDATE_CHANGED_FILES=lake-manifest.json lean-toolchain"
+  let actual := parseGHEnvLine "CHANGED_FILES" "LEAN_UPDATE_CHANGED_FILES=lake-manifest.json lean-toolchain"
   let expected := some "lake-manifest.json lean-toolchain"
   actual == expected
 
 #guard
-  GH.parseGHEnvLine "CHANGED_FILES" "LEAN_UPDATE_FILES_CHANGED=true" == none
+  parseGHEnvLine "CHANGED_FILES" "LEAN_UPDATE_FILES_CHANGED=true" == none
 
 /-- Read a value from the local GitHub Actions environment file. -/
-def GH.readLocalGHEnv (key : String) : IO String := do
+def readLocalGHEnv (key : String) : IO String := do
   let path : System.FilePath := Local.GITHUB_ENV
   if !(← path.pathExists) then
     throw <| IO.userError s!"Local GitHub Actions environment file '{path}' not found"
   let content ← IO.FS.readFile path
   let result? := content.lines.toList
     |>.map (·.copy)
-    |>.map (GH.parseGHEnvLine key ·)
+    |>.map (parseGHEnvLine key ·)
     |>.reverse
     |>.findSome? id
   pure <| result?.getD ""
 
-/-- Read a value previously written through `GH.writeGHEnv`. -/
-public def GH.readGHEnv (key : String) : IO (Option String) := do
+/-- Read a value previously written through `GitHub.Action.writeGHEnv`. -/
+public def readGHEnv (key : String) : IO (Option String) := do
   if (← isRunningGHAction) then
     IO.getEnv s!"LEAN_UPDATE_{key}"
   else
-    GH.readLocalGHEnv key
+    readLocalGHEnv key
 
-/-- Read a value previously written through `GH.writeGHEnv`.
+/-- Read a value previously written through `GitHub.Action.writeGHEnv`.
 This function throws an error if the environment variable is not found or is empty. -/
-public def GH.readGHEnv! (key : String) : IO String := do
+public def readGHEnv! (key : String) : IO String := do
   if (← isRunningGHAction) then
     let some value ← IO.getEnv s!"LEAN_UPDATE_{key}"
       | throw <| IO.userError s!"Environment variable 'LEAN_UPDATE_{key}' not found"
     pure value
   else
-    GH.readLocalGHEnv key
+    readLocalGHEnv key
+
+end GitHub.Action

--- a/LeanUpdate/GitHub/Action/Input.lean
+++ b/LeanUpdate/GitHub/Action/Input.lean
@@ -1,9 +1,11 @@
 module
 
-public import LeanUpdate.GH
+public import LeanUpdate.GitHub.Action.Env
+
+namespace GitHub.Action
 
 /-- the input value of GitHub Action -/
-public class ActionInput (α : Type) where
+public class Input (α : Type) where
   /-- the environment variable name which stores the input value -/
   envName : String
   /-- parse function for the input value -/
@@ -12,15 +14,17 @@ public class ActionInput (α : Type) where
   localValue? : Option α
 
 /-- get the input value from the environment variable or the local default value -/
-public def Input.get (α : Type) [ActionInput α] : IO α := do
-  let envVarName := ActionInput.envName α
+public def Input.get (α : Type) [Input α] : IO α := do
+  let envVarName := Input.envName α
   match (← IO.getEnv envVarName) with
   | .some valueStr =>
-    IO.ofExcept <| ActionInput.parse valueStr
+    IO.ofExcept <| Input.parse valueStr
   | .none =>
-    if !(← GH.isRunningGHAction) then
-      match (ActionInput.localValue? : Option α) with
+    if !(← isRunningGHAction) then
+      match (Input.localValue? : Option α) with
       | some localVal => pure localVal
       | none => throw <| IO.userError s!"Environment variable '{envVarName}' not found and no local default value provided."
     else
       throw <| IO.userError s!"Environment variable '{envVarName}' not found."
+
+end GitHub.Action

--- a/LeanUpdate/GitHub/Action/Input.lean
+++ b/LeanUpdate/GitHub/Action/Input.lean
@@ -1,6 +1,7 @@
 module
 
 public import LeanUpdate.GitHub.Action.Env
+public import LeanUpdate.Terminal
 
 namespace GitHub.Action
 
@@ -18,13 +19,16 @@ public def Input.get (α : Type) [Input α] : IO α := do
   let envVarName := Input.envName α
   match (← IO.getEnv envVarName) with
   | .some valueStr =>
+    IO.println <| log% s!"Input {``envVarName.toLower``} is set to {valueStr}"
     IO.ofExcept <| Input.parse valueStr
   | .none =>
     if !(← isRunningGHAction) then
       match (Input.localValue? : Option α) with
-      | some localVal => pure localVal
-      | none => throw <| IO.userError s!"Environment variable '{envVarName}' not found and no local default value provided."
+      | some localVal =>
+        IO.println <| log% s!"Using local default value for {``envVarName.toLower``}"
+        pure localVal
+      | none => throw <| IO.userError s!"Environment variable {``envVarName``} not found and no local default value provided."
     else
-      throw <| IO.userError s!"Environment variable '{envVarName}' not found."
+      throw <| IO.userError s!"Environment variable {``envVarName``} not found."
 
 end GitHub.Action

--- a/LeanUpdate/IO.lean
+++ b/LeanUpdate/IO.lean
@@ -2,6 +2,11 @@ module
 
 open IO Process System
 
+/-- Append a new line to a file. -/
+public def IO.FS.appendLineToFile (path : System.FilePath) (line : String) : IO Unit :=
+  IO.FS.withFile path IO.FS.Mode.append fun h => do
+    h.putStr s!"{line}\n"
+
 /-- Get environment variable or throw an error if not found. -/
 public def IO.getEnv! (key : String) : IO String := do
   match (← IO.getEnv key) with
@@ -9,8 +14,8 @@ public def IO.getEnv! (key : String) : IO String := do
   | .none => throw <| IO.userError s!"Environment variable '{key}' not found"
 
 /--
-Unset Lean/Lake toolchain-specific variables before running `lake update` in the
-target package. The lean-update executable itself runs under the action
+Unset Lean/Lake toolchain-specific variables before running `lake update` in
+the target package. The lean-update executable itself runs under the action
 package's Lake environment; inheriting those variables can make Lake restart
 with a mixture of the old action toolchain and the target package's new
 toolchain.

--- a/LeanUpdate/Input.lean
+++ b/LeanUpdate/Input.lean
@@ -5,7 +5,7 @@ public meta import LeanUpdate.Deriving.HasParser
 public meta import LeanUpdate.Deriving.Wrapper
 public import LeanUpdate.HasParser
 public import LeanUpdate.Wrapper
-public import LeanUpdate.ActionInput
+public import LeanUpdate.GitHub.Action.Input
 import LeanUpdate.IO
 
 open System
@@ -18,7 +18,7 @@ public inductive ReleaseKindToFetch where
   | nightly
 deriving Repr, BEq, ToString, HasParser
 
-public instance : ActionInput ReleaseKindToFetch where
+public instance : GitHub.Action.Input ReleaseKindToFetch where
   envName := "RELEASE_KIND_TO_FETCH"
   parse := parseAs ReleaseKindToFetch
   localValue? := some .tagged
@@ -29,7 +29,7 @@ public structure LakePackageDirectory where
   val : FilePath
 deriving Wrapper
 
-public instance : ActionInput LakePackageDirectory where
+public instance : GitHub.Action.Input LakePackageDirectory where
   envName := "LAKE_PACKAGE_DIRECTORY"
   parse := parseAs LakePackageDirectory
   localValue? := some ⟨FilePath.mk "."⟩
@@ -59,7 +59,7 @@ public def resolveLakePackageDir (workspace? : Option FilePath) (packageDir : Fi
 
 /-- resolve the target Lake package directory supplied by the action input. -/
 public def getTargetLakePackageDirectory : IO FilePath := do
-  let packageDir ← Input.get LakePackageDirectory
+  let packageDir ← GitHub.Action.Input.get LakePackageDirectory
   let workspace? := (← IO.getEnv "GITHUB_WORKSPACE").map FilePath.mk
   pure <| resolveLakePackageDir workspace? packageDir
 
@@ -69,7 +69,7 @@ public inductive UpdateLeanToolchain where
   | never
 deriving ToString, HasParser
 
-public instance : ActionInput UpdateLeanToolchain where
+public instance : GitHub.Action.Input UpdateLeanToolchain where
   envName := "UPDATE_LEAN_TOOLCHAIN"
   parse := parseAs UpdateLeanToolchain
   localValue? := some .auto
@@ -79,7 +79,7 @@ public structure LegacyUpdate where
   val : Bool
 deriving Wrapper
 
-public instance : ActionInput LegacyUpdate where
+public instance : GitHub.Action.Input LegacyUpdate where
   envName := "LEGACY_UPDATE"
   parse := parseAs LegacyUpdate
   localValue? := some ⟨false⟩
@@ -103,7 +103,7 @@ public structure BuildArgs where
   /-- the raw arguments after splitting on ASCII whitespace -/
   val : Array String
 
-public instance : ActionInput BuildArgs where
+public instance : GitHub.Action.Input BuildArgs where
   envName := "BUILD_ARGS"
   parse s := .ok ⟨splitBuildArgs s⟩
   localValue? := some ⟨#["--log-level=warning"]⟩
@@ -128,7 +128,7 @@ deriving Repr, BEq, ToString, HasParser
     |>.all id
   result
 
-public instance : ActionInput UpdateIfModified where
+public instance : GitHub.Action.Input UpdateIfModified where
   envName := "UPDATE_IF_MODIFIED"
   parse := parseAs UpdateIfModified
   localValue? := some .«lake-manifest.json»

--- a/LeanUpdate/Terminal.lean
+++ b/LeanUpdate/Terminal.lean
@@ -1,0 +1,34 @@
+module
+
+open Lean
+
+/-- add gray color to a string in terminal -/
+public def gray (s : String) : String :=
+  s!"\x1b[38;5;244m{s}\x1b[0m"
+
+/-- gray code syntax in terminal -/
+syntax (name := grayCode) "``" noWs ident "``" : term
+
+macro_rules
+  | `( ``$id`` ) => `(term| gray <| toString $id)
+
+/-- add green color to a string in terminal -/
+public def green (s : String) : String :=
+  s!"\x1b[38;5;10m{s}\x1b[0m"
+
+/-- add orange color to a string in terminal -/
+public def orange (s : String) : String :=
+  s!"\x1b[38;5;208m{s}\x1b[0m"
+
+/-- add bright blue color to a string in terminal -/
+public def blue (s : String) : String :=
+  s!"\x1b[94m{s}\x1b[0m"
+
+/-- add header for log messages -/
+syntax "log%" term : term
+
+macro_rules
+  | `(log% $msg) => `(term|
+    let header := blue s!"[{decl_name%}]"
+    s!"{header}: { $msg }"
+  )

--- a/LeanUpdate/UpdateDependencies.lean
+++ b/LeanUpdate/UpdateDependencies.lean
@@ -19,7 +19,7 @@ def lakeUpdateCommand (legacyUpdate : LegacyUpdate) : String :=
 
 /-- Run the dependency update command. -/
 public def runUpdateDependencies : IO Unit := do
-  let legacyUpdate ← Input.get LegacyUpdate
+  let legacyUpdate ← GitHub.Action.Input.get LegacyUpdate
   let targetLakePackageDir ← getTargetLakePackageDirectory
   if legacyUpdate then
     IO.println "Using legacy update command"

--- a/LeanUpdate/UpdateLeanToolchain.lean
+++ b/LeanUpdate/UpdateLeanToolchain.lean
@@ -8,6 +8,7 @@ import Std.Time.Format
 public meta import Lake.Util.Version
 public import Lake.Util.Version
 public import Std.Time
+public import LeanUpdate.Terminal
 
 open IO Process Lean Std Time
 
@@ -181,24 +182,19 @@ def exampleTaggedRelease : Array LeanTaggedRelease :=
   If it is set to `never`, this command does nothing. -/
 public def runUpdateLeanToolchain : IO Unit := do
   let updateLeanToolchain ← GitHub.Action.Input.get UpdateLeanToolchain
+
+  let releaseKind ← GitHub.Action.Input.get ReleaseKindToFetch
+  let latestRelease ← getLatestLeanRelease releaseKind
+  IO.println <| log% s!"Latest {releaseKind} Lean release: {latestRelease.toString}"
+  GitHub.Action.writeGHOutput "latest_lean" latestRelease.toString
+  GitHub.Action.writeGHEnv "LATEST_LEAN" latestRelease.toString
+
   match updateLeanToolchain with
   | .auto =>
-    IO.println "The input `update_lean_toolchain` is set to auto."
-
-    let releaseKind ← GitHub.Action.Input.get ReleaseKindToFetch
-    IO.println s!"Fetching the latest {releaseKind} Lean release..."
-
-    let latestRelease ← getLatestLeanRelease releaseKind
-    IO.println s!"Latest {releaseKind} Lean release: {latestRelease.toString}"
-    GitHub.Action.writeGHOutput "latest_lean" latestRelease.toString
-    GitHub.Action.writeGHEnv "LATEST_LEAN" latestRelease.toString
-
     let targetLakePackageDir ← getTargetLakePackageDirectory
     let leanToolchainFile := targetLakePackageDir / "lean-toolchain"
-
     IO.FS.writeFile leanToolchainFile s!"leanprover/lean4:{latestRelease.toString}\n"
-    IO.println s!"Updated {leanToolchainFile} with the latest {releaseKind} Lean release."
+    IO.println <| log% s!"Updated {leanToolchainFile} with the latest {releaseKind} Lean release."
   | .never =>
-    IO.println "The input `update_lean_toolchain` is set to never."
-    IO.println "Skipping fetching the latest Lean release and updating lean-toolchain file."
-    IO.println "Skipping setting the output `latest_lean` and environment variable `LEAN_UPDATE_LATEST_LEAN`."
+    IO.println <| log% "Skipping fetching the latest Lean release and updating lean-toolchain file."
+    IO.println <| log% "Skipping setting the output `latest_lean` and environment variable `LEAN_UPDATE_LATEST_LEAN`."

--- a/LeanUpdate/UpdateLeanToolchain.lean
+++ b/LeanUpdate/UpdateLeanToolchain.lean
@@ -1,7 +1,7 @@
 module
 
 import LeanUpdate.IO
-import LeanUpdate.GH
+import LeanUpdate.GitHub.Action.Env
 public meta import LeanUpdate.Input
 public import LeanUpdate.Input
 import Std.Time.Format
@@ -180,18 +180,18 @@ def exampleTaggedRelease : Array LeanTaggedRelease :=
 * The command read `UPDATE_LEAN_TOOLCHAIN`.
   If it is set to `never`, this command does nothing. -/
 public def runUpdateLeanToolchain : IO Unit := do
-  let updateLeanToolchain ← Input.get UpdateLeanToolchain
+  let updateLeanToolchain ← GitHub.Action.Input.get UpdateLeanToolchain
   match updateLeanToolchain with
   | .auto =>
     IO.println "The input `update_lean_toolchain` is set to auto."
 
-    let releaseKind ← Input.get ReleaseKindToFetch
+    let releaseKind ← GitHub.Action.Input.get ReleaseKindToFetch
     IO.println s!"Fetching the latest {releaseKind} Lean release..."
 
     let latestRelease ← getLatestLeanRelease releaseKind
     IO.println s!"Latest {releaseKind} Lean release: {latestRelease.toString}"
-    GH.writeOutput "latest_lean" latestRelease.toString
-    GH.writeGHEnv "LATEST_LEAN" latestRelease.toString
+    GitHub.Action.writeGHOutput "latest_lean" latestRelease.toString
+    GitHub.Action.writeGHEnv "LATEST_LEAN" latestRelease.toString
 
     let targetLakePackageDir ← getTargetLakePackageDirectory
     let leanToolchainFile := targetLakePackageDir / "lean-toolchain"

--- a/LeanUpdate/UpdateLeanToolchain.lean
+++ b/LeanUpdate/UpdateLeanToolchain.lean
@@ -189,12 +189,19 @@ public def runUpdateLeanToolchain : IO Unit := do
   GitHub.Action.writeGHOutput "latest_lean" latestRelease.toString
   GitHub.Action.writeGHEnv "LATEST_LEAN" latestRelease.toString
 
-  match updateLeanToolchain with
-  | .auto =>
+  let hasDependency ← GitHub.Action.readGHEnvAs! "HAS_DEPENDENCY" (expectedType := Bool)
+  match updateLeanToolchain, hasDependency with
+  | .auto, false =>
     let targetLakePackageDir ← getTargetLakePackageDirectory
     let leanToolchainFile := targetLakePackageDir / "lean-toolchain"
-    IO.FS.writeFile leanToolchainFile s!"leanprover/lean4:{latestRelease.toString}\n"
-    IO.println <| log% s!"Updated {leanToolchainFile} with the latest {releaseKind} Lean release."
-  | .never =>
-    IO.println <| log% "Skipping fetching the latest Lean release and updating lean-toolchain file."
-    IO.println <| log% "Skipping setting the output `latest_lean` and environment variable `LEAN_UPDATE_LATEST_LEAN`."
+
+    let oldLeanToolChainContent := (← IO.FS.readFile leanToolchainFile).trimAscii.copy
+    let newLeanToolchainContent := s!"leanprover/lean4:{latestRelease.toString}"
+
+    IO.FS.writeFile leanToolchainFile s!"{newLeanToolchainContent}\n"
+    if oldLeanToolChainContent == newLeanToolchainContent then
+      IO.println <| log% s!"lean-toolchain file is already up-to-date with the latest {releaseKind} Lean release."
+    else
+      IO.println <| log% s!"Updated {leanToolchainFile} with the latest {releaseKind} Lean release."
+  | _, _ =>
+    IO.println <| log% "Skipping fetching the updating lean-toolchain file."

--- a/LeanUpdate/UpdateLeanToolchain.lean
+++ b/LeanUpdate/UpdateLeanToolchain.lean
@@ -179,7 +179,7 @@ def exampleTaggedRelease : Array LeanTaggedRelease :=
   Note that `lake update` command also modifies the `lean-toolchain` file.
   So the resulting `lean-toolchain` file may not be the same as the latest release fetched by this command.
 * The command read `UPDATE_LEAN_TOOLCHAIN`.
-  If it is set to `never`, this command does nothing. -/
+  If it is set to `never`, this command does not upate `lean-toolchain` file. -/
 public def runUpdateLeanToolchain : IO Unit := do
   let updateLeanToolchain ← GitHub.Action.Input.get UpdateLeanToolchain
 
@@ -204,4 +204,4 @@ public def runUpdateLeanToolchain : IO Unit := do
     else
       IO.println <| log% s!"Updated {leanToolchainFile} with the latest {releaseKind} Lean release."
   | _, _ =>
-    IO.println <| log% "Skipping fetching the updating lean-toolchain file."
+    IO.println <| log% "Skipping updating lean-toolchain file."

--- a/action.yml
+++ b/action.yml
@@ -118,7 +118,7 @@ outputs:
 
       ## Note
       * This is not necessarily matching to the updated content of the lean-toolchain file of the lake package.
-      * This value is only set when `update_lean_toolchain` option is set to `auto` and the lake package has no dependencies.
+      * This value is fetched according to the `release_kind_to_fetch` option.
     value: ${{ steps.update-lean-toolchain.outputs.latest_lean }}
   notify:
     description: |
@@ -149,7 +149,6 @@ runs:
         LAKE_PACKAGE_DIRECTORY: ${{ inputs.lake_package_directory }}
 
     - name: Update lean-toolchain file
-      if: env.LEAN_UPDATE_HAS_DEPENDENCY == 'false'
       id: update-lean-toolchain
       run: |
         : Update lean-toolchain file


### PR DESCRIPTION


## Summary
- Always fetch the latest Lean release and set the `latest_lean` output based on `release_kind_to_fetch`.
- Keep `lean-toolchain` unchanged when the target package has dependencies, while still exposing the latest Lean version.
- Move GitHub Actions input/output/env helpers under `GitHub.Action`.
- Add workflow coverage for `latest_lean` output when dependencies are present.
