### PR TITLE
fix small problems

### DIFF
--- a/LeanUpdate/CreateIssue.lean
+++ b/LeanUpdate/CreateIssue.lean
@@ -41,14 +41,17 @@ public def createIssueBody (result : PostUpdateValidationResult) (changedFiles :
       "Update availabe and validated successfully."
     else
       "Try `lake update` and then investigate why this update causes `lake build`, `lake test`, or `lake lint` to fail."
-  let mut bodyList := [header]
+  let mut bodyList := [header, ""]
 
   let changedFilesMsg : List String :=
     match changedFiles with
     | [] => []
     | _ =>
-      let changedFileHeader := ["Files changed in update:", "",]
-      changedFileHeader ++ changedFiles.map (fun file => s!"- {file}") ++ [""]
+      let changedFileHeader := [
+        "## Files changed",
+        "",
+      ]
+      changedFileHeader ++ changedFiles.map (fun file => s!"- `{file}`") ++ [""]
   bodyList := bodyList ++ changedFilesMsg
 
   let truncationNotice := "...(truncated)"
@@ -138,6 +141,45 @@ public def createIssueBody (result : PostUpdateValidationResult) (changedFiles :
     lintResult? := some (.error longOutput)
   }
   (createIssueBody result []).length ≤ 65536
+
+/--
+info: Try `lake update` and then investigate why this update causes `lake build`, `lake test`, or `lake lint` to fail.
+
+## Files changed
+
+- `sample.txt`
+- `another.txt`
+
+## Build Output
+
+````
+Sample build error message
+````
+
+## Test Output
+
+````
+Sample test error message
+````
+
+## Lint Output
+
+````
+Sample lint error message
+````
+-/
+#guard_msgs in
+#eval
+  let sampleBuildResult : BuildResult := .error "Sample build error message"
+  let sampleTestResult : Except String Unit := .error "Sample test error message"
+  let sampleLintResult : Except String Unit := .error "Sample lint error message"
+  let result : PostUpdateValidationResult := {
+    buildResult := sampleBuildResult
+    testResult? := some sampleTestResult
+    lintResult? := some sampleLintResult
+  }
+  let body := createIssueBody result ["sample.txt", "another.txt"]
+  f!"{body}"
 
 /-- Create a GitHub issue describing an available Lean update. -/
 public def runCreateIssue : IO Unit := do

--- a/LeanUpdate/CreateIssue.lean
+++ b/LeanUpdate/CreateIssue.lean
@@ -4,12 +4,11 @@ import Lean
 import LeanUpdate.GitHub.Action.Env
 public import LeanUpdate.GitHub.Issue
 import LeanUpdate.Input
-import LeanUpdate.PostUpdateValidation
 public meta import LeanUpdate.GitHub.Repository
+public import      LeanUpdate.PostUpdateValidation
 public meta import LeanUpdate.PostUpdateValidation
 public import LeanUpdate.CheckChanges
-public meta import LeanUpdate.String
-public import LeanUpdate.String
+import all LeanUpdate.String
 
 open IO Process System GitHub.Issue
 
@@ -58,7 +57,7 @@ public def createIssueBody (result : PostUpdateValidationResult) (changedFiles :
   let outputTruncationLimit := 20000
   if !result.buildResult.isOk then
     let buildOutput := result.buildResult.toString
-      |> (String.truncateWithNotice · truncationNotice outputTruncationLimit)
+      |> (String.truncate · truncationNotice outputTruncationLimit)
     let buildResultMsg := [
       "## Build Output",
       "",
@@ -72,7 +71,7 @@ public def createIssueBody (result : PostUpdateValidationResult) (changedFiles :
   if let some testResult := result.testResult? then
     if !Except.isOk testResult then
       let testOutput := testResult.toString
-        |> (String.truncateWithNotice · truncationNotice outputTruncationLimit)
+        |> (String.truncate · truncationNotice outputTruncationLimit)
       let testResultMsg := [
         "## Test Output",
         "",
@@ -86,7 +85,7 @@ public def createIssueBody (result : PostUpdateValidationResult) (changedFiles :
   if let some lintResult := result.lintResult? then
     if !Except.isOk lintResult then
       let lintOutput := lintResult.toString
-        |> (String.truncateWithNotice · truncationNotice outputTruncationLimit)
+        |> (String.truncate · truncationNotice outputTruncationLimit)
       let lintResultMsg := [
         "## Lint Output",
         "",

--- a/LeanUpdate/GitHub/Issue.lean
+++ b/LeanUpdate/GitHub/Issue.lean
@@ -18,7 +18,8 @@ public structure Issue where
   /-- issue body. The maximum length of an issue body is **65536** characters. -/
   body : String
 
-/-- create an issue -/
+/-- Create an issue.
+This function is a simple wrapper of the GitHub CLI. -/
 public def Issue.create (issue : Issue) : IO Unit := do
   let _out ← IO.Process.successOutput {
     cmd := "gh"

--- a/LeanUpdate/GitHub/Repository.lean
+++ b/LeanUpdate/GitHub/Repository.lean
@@ -49,13 +49,13 @@ public def Repository.createLabel (repo : Repository) (labelName labelColor desc
   }
   IO.println s!"Created label '{labelName}' in repository {repo}"
 
-/-- Create a GitHub label if it does not already exist in a repository. -/
+/-- Create a GitHub label if it does not already exist in a repository.
+This is an idempotent version of `Repository.createLabel` -/
 public def Repository.createLabelIdem (repo : Repository) (labelName labelColor description : String) : IO Unit := do
   if !(← repo.hasLabel labelName) then
     repo.createLabel labelName labelColor description
 
-/-- Check if a GitHub repository has an open issue with a specific label.
-This is an idempotent version of `Repository.createLabel` -/
+/-- Check if a GitHub repository has an open issue with a specific label. -/
 public def Repository.hasOpenIssueWithLabel (repo : Repository) (labelName : String) : IO Bool := do
   let out ← IO.Process.successOutput {
     cmd := "gh"

--- a/LeanUpdate/IO.lean
+++ b/LeanUpdate/IO.lean
@@ -86,8 +86,7 @@ public def SuccessOutput.stdout (so : SuccessOutput) : String := so.val.stdout
 -/
 public def successOutput (args : SpawnArgs) (input? : Option String := none) : IO SuccessOutput := do
   let out ← IO.Process.output args (input? := input?)
-  let cmdStr := args.cmd ++ " " ++ String.intercalate " " (args.args.toList)
-  IO.println s!"Ran process: {cmdStr}"
+  IO.println s!"Ran process: {args.cmd} {args.args.toList}"
 
   if h : out.exitCode != 0 then
     throw <| IO.userError s!"Process failed with exit code {out.exitCode}:\n{out.stderr}"

--- a/LeanUpdate/IO.lean
+++ b/LeanUpdate/IO.lean
@@ -86,7 +86,8 @@ public def SuccessOutput.stdout (so : SuccessOutput) : String := so.val.stdout
 -/
 public def successOutput (args : SpawnArgs) (input? : Option String := none) : IO SuccessOutput := do
   let out ← IO.Process.output args (input? := input?)
-  IO.println s!"Ran process: {args.cmd} {args.args.toList}"
+  let cmdStr := args.cmd ++ " " ++ String.intercalate " " (args.args.toList)
+  IO.println s!"Ran process: {cmdStr}"
 
   if h : out.exitCode != 0 then
     throw <| IO.userError s!"Process failed with exit code {out.exitCode}:\n{out.stderr}"

--- a/LeanUpdate/String.lean
+++ b/LeanUpdate/String.lean
@@ -1,7 +1,8 @@
 module
 
 /-- truncate string -/
-public def String.truncateWithNotice (s truncationNotice : String) (maxLength : Nat) : String :=
+@[expose]
+public def String.truncate (s truncationNotice : String) (maxLength : Nat) : String :=
   if s.length ≤ maxLength then
     s
   else if truncationNotice.length < maxLength then
@@ -9,10 +10,10 @@ public def String.truncateWithNotice (s truncationNotice : String) (maxLength : 
   else
     (s.take maxLength).copy
 
-/-- the specification for `String.truncateWithNotice` -/
-theorem String.truncateWithNotice_spec (s notice : String) (max : Nat) :
-  (String.truncateWithNotice s notice max).length ≤ max := by
-  fun_cases String.truncateWithNotice s notice max
+/-- the specification for `String.truncate` -/
+theorem String.truncate_spec (s notice : String) (max : Nat) :
+  (String.truncate s notice max).length ≤ max := by
+  fun_cases String.truncate s notice max
   case case1 =>
     assumption
   case case2 if1 if2 =>

--- a/LeanUpdate/Terminal.lean
+++ b/LeanUpdate/Terminal.lean
@@ -24,7 +24,7 @@ public def orange (s : String) : String :=
 public def blue (s : String) : String :=
   s!"\x1b[94m{s}\x1b[0m"
 
-/-- add header for log messages -/
+/-- add function name header for log messages -/
 syntax "log%" term : term
 
 macro_rules

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -11,7 +11,6 @@ lean_lib «LeanUpdate» where
   leanOptions := #[
     ⟨`linter.missingDocs, true⟩
   ]
-  requiresModuleSystem := true
 
 lean_exe leanUpdate where
   root := `Main


### PR DESCRIPTION
## Summary

This PR cleans up several small inconsistencies across the project.

- Improve the formatting of generated GitHub issue bodies:
  - format filenames as inline code
  - improve spacing between sections
  - add a regression test for the rendered body
- Rename `String.truncateWithNotice` to `String.truncate`, expose it, and update its specification and callers
- Format process log messages as shell-like commands instead of Lean array syntax
- Fix several inaccurate or unclear docstrings
- Remove the `requiresModuleSystem := true` setting
