### PR TITLE
Pin add-and-commit to v11.0.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -293,7 +293,7 @@ runs:
 
     - name: Commit update if post-update validation was successful
       if: steps.validate-update.outcome == 'success' && inputs.on_update_succeeds == 'commit' && env.LEAN_UPDATE_DO_UPDATE == 'true'
-      uses: EndBug/add-and-commit@v11
+      uses: EndBug/add-and-commit@645ecc0dd0a57f4d86d26c0aa5fc42c0a856fbca # v11.0.0
       with:
         default_author: github_actions
       env:


### PR DESCRIPTION
## Summary

- pin `EndBug/add-and-commit` to the v11.0.0 commit SHA
- prevent the mutable `v11` tag from silently resolving to the broken v11.1.0 release

## Root cause

`EndBug/add-and-commit@v11` moved from the working v11.0.0 commit (`645ecc0`) to v11.1.0 (`fc1cf1d`). The newer action metadata contains `${{ github.workspace }}` in an input description, which GitHub Actions attempts to evaluate while preparing the job and rejects with `Unrecognized named-value: 'github'`.

Composite-action dependencies are prepared before step conditions are evaluated, so this also breaks lean-update users that do not select the `commit` mode.

Related upstream issue: https://github.com/EndBug/add-and-commit/issues/782

## Impact

This restores lean-update consumers currently failing during `Set up job`, including:

- https://github.com/Seasawher/mdgen/actions/runs/32245803953
- https://github.com/leanprover-community/lean-update/actions/runs/32199703796

Pinning the full commit SHA also prevents future changes to the major-version tag from bypassing this repository's review and CI.

## Validation

- `git diff --check`
- confirmed the pinned SHA was used successfully by https://github.com/Seasawher/mdgen/actions/runs/32129971078
- `actionlint` was not available in the local environment
